### PR TITLE
Fix Parsing Messages With Quotes

### DIFF
--- a/eq_bot/game/buff/buff_manager.py
+++ b/eq_bot/game/buff/buff_manager.py
@@ -13,6 +13,7 @@ class BuffManager:
         self._guild_tracker = guild_tracker
 
     def handle_tell_message(self, tell_message):
+        print('TELL MESSAGE', tell_message)
         # TODO: Enqueue and process messages when window is not busy given that messages will come in asynchronously
 
         # Do not proceed if restrict to guildies enabled and is not a guild member

--- a/eq_bot/game/buff/buff_manager.py
+++ b/eq_bot/game/buff/buff_manager.py
@@ -13,7 +13,6 @@ class BuffManager:
         self._guild_tracker = guild_tracker
 
     def handle_tell_message(self, tell_message):
-        print('TELL MESSAGE', tell_message)
         # TODO: Enqueue and process messages when window is not busy given that messages will come in asynchronously
 
         # Do not proceed if restrict to guildies enabled and is not a guild member

--- a/eq_bot/game/logging/log_message_parser.py
+++ b/eq_bot/game/logging/log_message_parser.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from game.logging.entities.log_message import LogMessage, LogMessageType
 
@@ -45,6 +46,9 @@ def _parse_message_to(full_message, message_split, message_type):
         return message_split[2].rstrip(',').capitalize()
     # TODO: Log warning
 
+def _parse_inner_message(full_message):
+    return re.search(", '(.*)'$", full_message).group(1)
+
 def create_log_message(raw_text):
     full_message = raw_text[27:].rstrip('\n')
     message_split = full_message.split(' ')
@@ -57,6 +61,6 @@ def create_log_message(raw_text):
         to = _parse_message_to(full_message, message_split, message_type),
         # remove the surrounding quotes from player message
         # e.g. Soandso tells you, 'this is the inner message'
-        inner_message = message_split[-1][1:-1] if is_player_message else None,
+        inner_message = _parse_inner_message(full_message) if is_player_message else None,
         full_message = full_message,
         message_type = message_type)

--- a/eq_bot/game/logging/log_message_parser.py
+++ b/eq_bot/game/logging/log_message_parser.py
@@ -1,4 +1,3 @@
-import shlex
 from datetime import datetime
 from game.logging.entities.log_message import LogMessage, LogMessageType
 
@@ -48,7 +47,7 @@ def _parse_message_to(full_message, message_split, message_type):
 
 def create_log_message(raw_text):
     full_message = raw_text[27:].rstrip('\n')
-    message_split = shlex.split(full_message)
+    message_split = full_message.split(' ')
     message_type = _parse_message_type(full_message, message_split)
     is_player_message = message_type != LogMessageType.UNKNOWN
 
@@ -56,6 +55,8 @@ def create_log_message(raw_text):
         timestamp = _parse_timestamp(raw_text[0:26]),
         from_player = message_split[0] if is_player_message else None,
         to = _parse_message_to(full_message, message_split, message_type),
-        inner_message = message_split[-1] if is_player_message else None,
+        # remove the surrounding quotes from player message
+        # e.g. Soandso tells you, 'this is the inner message'
+        inner_message = message_split[-1][1:-1] if is_player_message else None,
         full_message = full_message,
         message_type = message_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ python-dateutil==2.8.2
 discord==1.7.3
 requests==2.28.1
 PyYAML==6.0
-requests==2.28.1


### PR DESCRIPTION
Not sure why I used shlex to parse the incoming message.. I think it was to parse the enclosing message within quotes. I.e. Soandso tells you, 'This is the enclosing message!!!'

But that would then blow up if there were quotes within the inner message.

With this change, we're simply using a regex to parse the inner message.