### PR TITLE
Fix Parsing of Messages with Quotes

### DIFF
--- a/eq_bot/game/buff/buff_manager.py
+++ b/eq_bot/game/buff/buff_manager.py
@@ -13,6 +13,7 @@ class BuffManager:
         self._guild_tracker = guild_tracker
 
     def handle_tell_message(self, tell_message):
+        print('TELL MESSAGE', tell_message)
         # TODO: Enqueue and process messages when window is not busy given that messages will come in asynchronously
 
         # Do not proceed if restrict to guildies enabled and is not a guild member

--- a/eq_bot/game/buff/buff_manager.py
+++ b/eq_bot/game/buff/buff_manager.py
@@ -16,7 +16,7 @@ class BuffManager:
         # TODO: Enqueue and process messages when window is not busy given that messages will come in asynchronously
 
         # Do not proceed if restrict to guildies enabled and is not a guild member
-        if RESTRICT_TO_GUILDIES and not self._guild_tracker.is_a_member(tell_message.from_player):
+        if RESTRICT_TO_GUILDIES and not self._guild_tracker.is_a_member(tell_message.from_character):
             # TODO: Log a warning
             return
         
@@ -31,13 +31,13 @@ class BuffManager:
 
         self._eq_window.activate()
         # TODO: Check if player was not found in zone and inform them
-        self._eq_window.target(tell_message.from_player)
-        self._eq_window.send_chat_message(f"/tell {tell_message.from_player} Incoming")
+        self._eq_window.target(tell_message.from_character)
+        self._eq_window.send_chat_message(f"/tell {tell_message.from_character} Incoming")
         # TODO: Check if player was too far and inform them
 
         for spell_name in spells_to_cast:
             spell_config = BUFFING_SPELLS[spell_name]
-            self._eq_window.cast_spell(tell_message.from_player, spell_name, spell_config['spell_slot'])
+            self._eq_window.cast_spell(tell_message.from_character, spell_name, spell_config['spell_slot'])
             recast_time = spell_config.get('recast_time', 1)
             time.sleep(spell_config['cast_time'] + recast_time)
 

--- a/eq_bot/game/buff/buff_manager.py
+++ b/eq_bot/game/buff/buff_manager.py
@@ -13,7 +13,6 @@ class BuffManager:
         self._guild_tracker = guild_tracker
 
     def handle_tell_message(self, tell_message):
-        print('TELL MESSAGE', tell_message)
         # TODO: Enqueue and process messages when window is not busy given that messages will come in asynchronously
 
         # Do not proceed if restrict to guildies enabled and is not a guild member

--- a/eq_bot/game/logging/entities/log_message.py
+++ b/eq_bot/game/logging/entities/log_message.py
@@ -22,7 +22,7 @@ class LogMessage:
     timestamp: datetime
     full_message: str
     inner_message: str
-    from_player: str
+    from_character: str
     to: str
     message_type: LogMessageType
 

--- a/eq_bot/game/logging/log_message_parser.py
+++ b/eq_bot/game/logging/log_message_parser.py
@@ -72,8 +72,6 @@ def create_log_message(raw_text):
         timestamp = _parse_timestamp(raw_text[0:26]),
         from_character = message_split[0] if is_communication_message else None,
         to = _parse_message_to(full_message, message_split, message_type),
-        # remove the surrounding quotes from player message
-        # e.g. Soandso tells you, 'this is the inner message'
         inner_message = _parse_inner_message(full_message) if is_communication_message else None,
         full_message = full_message,
         message_type = message_type)

--- a/eq_bot/game/logging/log_message_parser.py
+++ b/eq_bot/game/logging/log_message_parser.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from game.logging.entities.log_message import LogMessage, LogMessageType
 
@@ -45,6 +46,9 @@ def _parse_message_to(full_message, message_split, message_type):
         return message_split[2].rstrip(',').capitalize()
     # TODO: Log warning
 
+def _parse_inner_message(full_message):
+    return re.search(", '(.*)'$", full_message).group(1)
+
 def create_log_message(raw_text):
     full_message = raw_text[27:].rstrip('\n')
     message_split = full_message.split(' ')
@@ -57,6 +61,6 @@ def create_log_message(raw_text):
         to = _parse_message_to(full_message, message_split, message_type),
         # remove the surrounding quotes from player message
         # e.g. Soandso tells you, 'this is the inner message'
-        inner_message = message_split[-1][1:-1] if is_player_message else None,
+        inner_message = _parse_inner_message(full_message) if is_player_message else None,
         full_message = full_message,
         message_type = message_type)

--- a/eq_bot/game/logging/log_message_parser.py
+++ b/eq_bot/game/logging/log_message_parser.py
@@ -1,4 +1,3 @@
-import shlex
 from datetime import datetime
 from game.logging.entities.log_message import LogMessage, LogMessageType
 
@@ -48,7 +47,7 @@ def _parse_message_to(full_message, message_split, message_type):
 
 def create_log_message(raw_text):
     full_message = raw_text[27:].rstrip('\n')
-    message_split = shlex.split(full_message)
+    message_split = full_message.split(' ')
     message_type = _parse_message_type(full_message, message_split)
     is_player_message = message_type != LogMessageType.UNKNOWN
 
@@ -56,6 +55,8 @@ def create_log_message(raw_text):
         timestamp = _parse_timestamp(raw_text[0:26]),
         from_player = message_split[0] if is_player_message else None,
         to = _parse_message_to(full_message, message_split, message_type),
-        inner_message = message_split[-1] if is_player_message else None,
+        # remove the surrounding quotes from player message
+        # e.g. Soandso tells you, 'this is the inner message'
+        inner_message = message_split[-1][1:-1] if is_player_message else None,
         full_message = full_message,
         message_type = message_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ python-dateutil==2.8.2
 discord==1.7.3
 requests==2.28.1
 PyYAML==6.0
-requests==2.28.1


### PR DESCRIPTION
Not sure why I used shlex to parse the incoming message.. I think it was to parse the enclosing message within quotes. I.e. Soandso tells you, 'This is the enclosing message!!!'

But that would then blow up if there were quotes within the inner message.

With this change, we're simply using a regex to parse the inner message.

I also renamed some variables from the context of "player" to "character" since a /say message, for example, _could_ be from a NPC.